### PR TITLE
Add multi-step new coach setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "remark-gfm": "^4.0.1",
     "stripe": "^18.2.0",
     "uuid": "^11.1.0",
-    "zod": "^3.25.42"
+    "zod": "^3.25.42",
+    "swiper": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/src/app/(standalone)/new-coach/_steps/Step1.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step1.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { Input } from '@/shared/Input';
+import { StepProps } from './StepProps';
+
+export default function Step1({ question, value, onChange }: StepProps) {
+  return (
+    <div className="flex w-full max-w-md flex-col gap-y-4">
+      <p className="text-lg text-main">{question}</p>
+      <Input
+        id={`answer-1`}
+        value={value}
+        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
+        inputClassName="border-main bg-transparent"
+      />
+    </div>
+  );
+}

--- a/src/app/(standalone)/new-coach/_steps/Step10.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step10.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { Input } from '@/shared/Input';
+import { StepProps } from './StepProps';
+
+export default function Step10({ question, value, onChange }: StepProps) {
+  return (
+    <div className="flex w-full max-w-md flex-col gap-y-4">
+      <p className="text-lg text-main">{question}</p>
+      <Input
+        id={`answer-10`}
+        value={value}
+        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
+        inputClassName="border-main bg-transparent"
+      />
+    </div>
+  );
+}

--- a/src/app/(standalone)/new-coach/_steps/Step2.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step2.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { Input } from '@/shared/Input';
+import { StepProps } from './StepProps';
+
+export default function Step2({ question, value, onChange }: StepProps) {
+  return (
+    <div className="flex w-full max-w-md flex-col gap-y-4">
+      <p className="text-lg text-main">{question}</p>
+      <Input
+        id={`answer-2`}
+        value={value}
+        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
+        inputClassName="border-main bg-transparent"
+      />
+    </div>
+  );
+}

--- a/src/app/(standalone)/new-coach/_steps/Step3.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step3.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { Input } from '@/shared/Input';
+import { StepProps } from './StepProps';
+
+export default function Step3({ question, value, onChange }: StepProps) {
+  return (
+    <div className="flex w-full max-w-md flex-col gap-y-4">
+      <p className="text-lg text-main">{question}</p>
+      <Input
+        id={`answer-3`}
+        value={value}
+        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
+        inputClassName="border-main bg-transparent"
+      />
+    </div>
+  );
+}

--- a/src/app/(standalone)/new-coach/_steps/Step4.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step4.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { Input } from '@/shared/Input';
+import { StepProps } from './StepProps';
+
+export default function Step4({ question, value, onChange }: StepProps) {
+  return (
+    <div className="flex w-full max-w-md flex-col gap-y-4">
+      <p className="text-lg text-main">{question}</p>
+      <Input
+        id={`answer-4`}
+        value={value}
+        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
+        inputClassName="border-main bg-transparent"
+      />
+    </div>
+  );
+}

--- a/src/app/(standalone)/new-coach/_steps/Step5.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step5.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { Input } from '@/shared/Input';
+import { StepProps } from './StepProps';
+
+export default function Step5({ question, value, onChange }: StepProps) {
+  return (
+    <div className="flex w-full max-w-md flex-col gap-y-4">
+      <p className="text-lg text-main">{question}</p>
+      <Input
+        id={`answer-5`}
+        value={value}
+        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
+        inputClassName="border-main bg-transparent"
+      />
+    </div>
+  );
+}

--- a/src/app/(standalone)/new-coach/_steps/Step6.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step6.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { Input } from '@/shared/Input';
+import { StepProps } from './StepProps';
+
+export default function Step6({ question, value, onChange }: StepProps) {
+  return (
+    <div className="flex w-full max-w-md flex-col gap-y-4">
+      <p className="text-lg text-main">{question}</p>
+      <Input
+        id={`answer-6`}
+        value={value}
+        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
+        inputClassName="border-main bg-transparent"
+      />
+    </div>
+  );
+}

--- a/src/app/(standalone)/new-coach/_steps/Step7.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step7.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { Input } from '@/shared/Input';
+import { StepProps } from './StepProps';
+
+export default function Step7({ question, value, onChange }: StepProps) {
+  return (
+    <div className="flex w-full max-w-md flex-col gap-y-4">
+      <p className="text-lg text-main">{question}</p>
+      <Input
+        id={`answer-7`}
+        value={value}
+        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
+        inputClassName="border-main bg-transparent"
+      />
+    </div>
+  );
+}

--- a/src/app/(standalone)/new-coach/_steps/Step8.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step8.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { Input } from '@/shared/Input';
+import { StepProps } from './StepProps';
+
+export default function Step8({ question, value, onChange }: StepProps) {
+  return (
+    <div className="flex w-full max-w-md flex-col gap-y-4">
+      <p className="text-lg text-main">{question}</p>
+      <Input
+        id={`answer-8`}
+        value={value}
+        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
+        inputClassName="border-main bg-transparent"
+      />
+    </div>
+  );
+}

--- a/src/app/(standalone)/new-coach/_steps/Step9.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step9.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { Input } from '@/shared/Input';
+import { StepProps } from './StepProps';
+
+export default function Step9({ question, value, onChange }: StepProps) {
+  return (
+    <div className="flex w-full max-w-md flex-col gap-y-4">
+      <p className="text-lg text-main">{question}</p>
+      <Input
+        id={`answer-9`}
+        value={value}
+        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
+        inputClassName="border-main bg-transparent"
+      />
+    </div>
+  );
+}

--- a/src/app/(standalone)/new-coach/_steps/StepProps.ts
+++ b/src/app/(standalone)/new-coach/_steps/StepProps.ts
@@ -1,0 +1,5 @@
+export interface StepProps {
+  question: string;
+  value: string;
+  onChange: (value: string) => void;
+}

--- a/src/app/(standalone)/new-coach/page.tsx
+++ b/src/app/(standalone)/new-coach/page.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { Button } from '@/shared/Button';
+
+export default function NewCoachWelcome() {
+  return (
+    <div className="flex flex-col items-center gap-y-6 p-6">
+      <h1 className="text-2xl font-bold text-main">Welcome to the Coach Setup</h1>
+      <Button href="/new-coach/steps" variant="solid" color="light">
+        Start
+      </Button>
+    </div>
+  );
+}

--- a/src/app/(standalone)/new-coach/steps/page.tsx
+++ b/src/app/(standalone)/new-coach/steps/page.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { Button } from '@/shared/Button';
+import Step1 from '../_steps/Step1';
+import Step2 from '../_steps/Step2';
+import Step3 from '../_steps/Step3';
+import Step4 from '../_steps/Step4';
+import Step5 from '../_steps/Step5';
+import Step6 from '../_steps/Step6';
+import Step7 from '../_steps/Step7';
+import Step8 from '../_steps/Step8';
+import Step9 from '../_steps/Step9';
+import Step10 from '../_steps/Step10';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Pagination } from 'swiper/modules';
+import type { Swiper as SwiperType } from 'swiper';
+import 'swiper/css';
+import 'swiper/css/pagination';
+
+export default function NewCoach() {
+  const questions = Array.from({ length: 10 }, (_, i) => `Question ${i + 1}`);
+  const [answers, setAnswers] = useState<string[]>(Array(10).fill(''));
+  const [step, setStep] = useState(0);
+  const swiperRef = useRef<SwiperType | null>(null);
+
+  const steps = [
+    Step1,
+    Step2,
+    Step3,
+    Step4,
+    Step5,
+    Step6,
+    Step7,
+    Step8,
+    Step9,
+    Step10,
+  ];
+
+  const handleChange = (index: number, value: string) => {
+    setAnswers((prev) => {
+      const copy = [...prev];
+      copy[index] = value;
+      return copy;
+    });
+  };
+
+  const prevStep = () => swiperRef.current?.slidePrev();
+  const nextStep = () => swiperRef.current?.slideNext();
+
+  return (
+    <div className="flex min-h-0 flex-col items-center gap-y-6 p-6">
+      <Swiper
+        modules={[Pagination]}
+        pagination={{ clickable: true }}
+        onSwiper={(s) => (swiperRef.current = s)}
+        onSlideChange={(s) => setStep(s.activeIndex)}
+        className="w-full flex-1"
+      >
+        {steps.map((StepComponent, i) => (
+          <SwiperSlide key={`step-${i}`} className="flex justify-center">
+            <StepComponent
+              question={questions[i]}
+              value={answers[i]}
+              onChange={(val) => handleChange(i, val)}
+            />
+          </SwiperSlide>
+        ))}
+      </Swiper>
+
+      <div className="flex gap-x-2">
+        <Button
+          onClick={prevStep}
+          variant="outline"
+          color="darkGray"
+          disabled={step === 0}
+          className="cbi-arrow-left aspect-square px-3 text-xl"
+        />
+        <Button
+          onClick={nextStep}
+          variant="solid"
+          color="light"
+          disabled={step === questions.length - 1}
+          className="flex items-center gap-x-2"
+        >
+          Next
+          <i className="cbi-arrow-right text-xl" />
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce welcome screen and start button for new coach setup
- create separate components for each step of a 10-step questionnaire
- move questionnaire logic to new `steps` page using the step components
- fix navigation from Start button and integrate Swiper for gallery-style steps

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_684b3489972c8329ad4df91e66082dec