### PR TITLE
Add logo and progress indicators to new coach setup

### DIFF
--- a/src/app/(standalone)/new-coach/_steps/Step1.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step1.tsx
@@ -1,17 +1,18 @@
-'use client';
+"use client";
 
-import { Input } from '@/shared/Input';
-import { StepProps } from './StepProps';
+import { Input } from "@/shared/Input";
+import { StepProps } from "./StepProps";
 
 export default function Step1({ question, value, onChange }: StepProps) {
   return (
     <div className="flex w-full max-w-md flex-col gap-y-4">
-      <p className="text-lg text-main">{question}</p>
+      <p className="text-center text-lg text-main">{question}</p>
       <Input
         id={`answer-1`}
         value={value}
         onChange={(e) => onChange((e.target as HTMLInputElement).value)}
         inputClassName="border-main bg-transparent"
+        readOnly={false}
       />
     </div>
   );

--- a/src/app/(standalone)/new-coach/_steps/Step10.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step10.tsx
@@ -1,17 +1,18 @@
-'use client';
+"use client";
 
-import { Input } from '@/shared/Input';
-import { StepProps } from './StepProps';
+import { Input } from "@/shared/Input";
+import { StepProps } from "./StepProps";
 
 export default function Step10({ question, value, onChange }: StepProps) {
   return (
     <div className="flex w-full max-w-md flex-col gap-y-4">
-      <p className="text-lg text-main">{question}</p>
+      <p className="text-center text-lg text-main">{question}</p>
       <Input
         id={`answer-10`}
         value={value}
         onChange={(e) => onChange((e.target as HTMLInputElement).value)}
         inputClassName="border-main bg-transparent"
+        readOnly={false}
       />
     </div>
   );

--- a/src/app/(standalone)/new-coach/_steps/Step2.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step2.tsx
@@ -1,17 +1,18 @@
-'use client';
+"use client";
 
-import { Input } from '@/shared/Input';
-import { StepProps } from './StepProps';
+import { Input } from "@/shared/Input";
+import { StepProps } from "./StepProps";
 
 export default function Step2({ question, value, onChange }: StepProps) {
   return (
     <div className="flex w-full max-w-md flex-col gap-y-4">
-      <p className="text-lg text-main">{question}</p>
+      <p className="text-center text-lg text-main">{question}</p>
       <Input
         id={`answer-2`}
         value={value}
         onChange={(e) => onChange((e.target as HTMLInputElement).value)}
         inputClassName="border-main bg-transparent"
+        readOnly={false}
       />
     </div>
   );

--- a/src/app/(standalone)/new-coach/_steps/Step3.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step3.tsx
@@ -1,17 +1,18 @@
-'use client';
+"use client";
 
-import { Input } from '@/shared/Input';
-import { StepProps } from './StepProps';
+import { Input } from "@/shared/Input";
+import { StepProps } from "./StepProps";
 
 export default function Step3({ question, value, onChange }: StepProps) {
   return (
     <div className="flex w-full max-w-md flex-col gap-y-4">
-      <p className="text-lg text-main">{question}</p>
+      <p className="text-center text-lg text-main">{question}</p>
       <Input
         id={`answer-3`}
         value={value}
         onChange={(e) => onChange((e.target as HTMLInputElement).value)}
         inputClassName="border-main bg-transparent"
+        readOnly={false}
       />
     </div>
   );

--- a/src/app/(standalone)/new-coach/_steps/Step4.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step4.tsx
@@ -1,17 +1,18 @@
-'use client';
+"use client";
 
-import { Input } from '@/shared/Input';
-import { StepProps } from './StepProps';
+import { Input } from "@/shared/Input";
+import { StepProps } from "./StepProps";
 
 export default function Step4({ question, value, onChange }: StepProps) {
   return (
     <div className="flex w-full max-w-md flex-col gap-y-4">
-      <p className="text-lg text-main">{question}</p>
+      <p className="text-center text-lg text-main">{question}</p>
       <Input
         id={`answer-4`}
         value={value}
         onChange={(e) => onChange((e.target as HTMLInputElement).value)}
         inputClassName="border-main bg-transparent"
+        readOnly={false}
       />
     </div>
   );

--- a/src/app/(standalone)/new-coach/_steps/Step5.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step5.tsx
@@ -1,17 +1,18 @@
-'use client';
+"use client";
 
-import { Input } from '@/shared/Input';
-import { StepProps } from './StepProps';
+import { Input } from "@/shared/Input";
+import { StepProps } from "./StepProps";
 
 export default function Step5({ question, value, onChange }: StepProps) {
   return (
     <div className="flex w-full max-w-md flex-col gap-y-4">
-      <p className="text-lg text-main">{question}</p>
+      <p className="text-center text-lg text-main">{question}</p>
       <Input
         id={`answer-5`}
         value={value}
         onChange={(e) => onChange((e.target as HTMLInputElement).value)}
         inputClassName="border-main bg-transparent"
+        readOnly={false}
       />
     </div>
   );

--- a/src/app/(standalone)/new-coach/_steps/Step6.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step6.tsx
@@ -1,17 +1,18 @@
-'use client';
+"use client";
 
-import { Input } from '@/shared/Input';
-import { StepProps } from './StepProps';
+import { Input } from "@/shared/Input";
+import { StepProps } from "./StepProps";
 
 export default function Step6({ question, value, onChange }: StepProps) {
   return (
     <div className="flex w-full max-w-md flex-col gap-y-4">
-      <p className="text-lg text-main">{question}</p>
+      <p className="text-center text-lg text-main">{question}</p>
       <Input
         id={`answer-6`}
         value={value}
         onChange={(e) => onChange((e.target as HTMLInputElement).value)}
         inputClassName="border-main bg-transparent"
+        readOnly={false}
       />
     </div>
   );

--- a/src/app/(standalone)/new-coach/_steps/Step7.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step7.tsx
@@ -1,17 +1,18 @@
-'use client';
+"use client";
 
-import { Input } from '@/shared/Input';
-import { StepProps } from './StepProps';
+import { Input } from "@/shared/Input";
+import { StepProps } from "./StepProps";
 
 export default function Step7({ question, value, onChange }: StepProps) {
   return (
     <div className="flex w-full max-w-md flex-col gap-y-4">
-      <p className="text-lg text-main">{question}</p>
+      <p className="text-center text-lg text-main">{question}</p>
       <Input
         id={`answer-7`}
         value={value}
         onChange={(e) => onChange((e.target as HTMLInputElement).value)}
         inputClassName="border-main bg-transparent"
+        readOnly={false}
       />
     </div>
   );

--- a/src/app/(standalone)/new-coach/_steps/Step8.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step8.tsx
@@ -1,17 +1,18 @@
-'use client';
+"use client";
 
-import { Input } from '@/shared/Input';
-import { StepProps } from './StepProps';
+import { Input } from "@/shared/Input";
+import { StepProps } from "./StepProps";
 
 export default function Step8({ question, value, onChange }: StepProps) {
   return (
     <div className="flex w-full max-w-md flex-col gap-y-4">
-      <p className="text-lg text-main">{question}</p>
+      <p className="text-center text-lg text-main">{question}</p>
       <Input
         id={`answer-8`}
         value={value}
         onChange={(e) => onChange((e.target as HTMLInputElement).value)}
         inputClassName="border-main bg-transparent"
+        readOnly={false}
       />
     </div>
   );

--- a/src/app/(standalone)/new-coach/_steps/Step9.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step9.tsx
@@ -1,17 +1,18 @@
-'use client';
+"use client";
 
-import { Input } from '@/shared/Input';
-import { StepProps } from './StepProps';
+import { Input } from "@/shared/Input";
+import { StepProps } from "./StepProps";
 
 export default function Step9({ question, value, onChange }: StepProps) {
   return (
     <div className="flex w-full max-w-md flex-col gap-y-4">
-      <p className="text-lg text-main">{question}</p>
+      <p className="text-center text-lg text-main">{question}</p>
       <Input
         id={`answer-9`}
         value={value}
         onChange={(e) => onChange((e.target as HTMLInputElement).value)}
         inputClassName="border-main bg-transparent"
+        readOnly={false}
       />
     </div>
   );

--- a/src/app/(standalone)/new-coach/page.tsx
+++ b/src/app/(standalone)/new-coach/page.tsx
@@ -1,13 +1,16 @@
-'use client';
+"use client";
 
-import { Button } from '@/shared/Button';
+import { Button } from "@/shared/Button";
+import { Logo } from "@/shared/Logo";
 
 export default function NewCoachWelcome() {
   return (
     <div className="flex flex-col items-center gap-y-6 p-6">
-      <h1 className="text-2xl font-bold text-main">Welcome to the Coach Setup</h1>
+      <Logo className="mx-auto h-10 w-auto" />
+      <h1 className="text-2xl font-bold text-main">
+        Welcome to the Coach Setup
+      </h1>
       <Button href="/new-coach/steps" variant="solid" color="light">
-
         Start
       </Button>
     </div>

--- a/src/app/(standalone)/new-coach/steps/page.tsx
+++ b/src/app/(standalone)/new-coach/steps/page.tsx
@@ -1,24 +1,23 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import { Button } from '@/shared/Button';
-import Step1 from '../_steps/Step1';
-import Step2 from '../_steps/Step2';
-import Step3 from '../_steps/Step3';
-import Step4 from '../_steps/Step4';
-import Step5 from '../_steps/Step5';
-import Step6 from '../_steps/Step6';
-import Step7 from '../_steps/Step7';
-import Step8 from '../_steps/Step8';
-import Step9 from '../_steps/Step9';
-import Step10 from '../_steps/Step10';
-
+import { useState } from "react";
+import { Button } from "@/shared/Button";
+import { Logo } from "@/shared/Logo";
+import Step1 from "../_steps/Step1";
+import Step2 from "../_steps/Step2";
+import Step3 from "../_steps/Step3";
+import Step4 from "../_steps/Step4";
+import Step5 from "../_steps/Step5";
+import Step6 from "../_steps/Step6";
+import Step7 from "../_steps/Step7";
+import Step8 from "../_steps/Step8";
+import Step9 from "../_steps/Step9";
+import Step10 from "../_steps/Step10";
 
 export default function NewCoach() {
   const questions = Array.from({ length: 10 }, (_, i) => `Question ${i + 1}`);
-  const [answers, setAnswers] = useState<string[]>(Array(10).fill(''));
+  const [answers, setAnswers] = useState<string[]>(Array(10).fill(""));
   const [step, setStep] = useState(0);
-
 
   const steps = [
     Step1,
@@ -47,6 +46,15 @@ export default function NewCoach() {
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-y-6 p-6">
+      <Logo className="mx-auto mb-4 h-10 w-auto" />
+      <div className="mb-4 flex justify-center gap-x-2">
+        {questions.map((_, i) => (
+          <span
+            key={i}
+            className={`h-2 w-2 rounded-full ${i === step ? "bg-blue-400" : "bg-gray-400"}`}
+          />
+        ))}
+      </div>
       <div className="flex w-full flex-1 items-center justify-center">
         {(() => {
           const StepComponent = steps[step];


### PR DESCRIPTION
## Summary
- center logo on new coach pages
- allow typing in questions and center their text
- show progress dots for each question step

## Testing
- `npx eslint "src/app/(standalone)/new-coach/**/*.tsx"`

------
https://chatgpt.com/codex/tasks/task_e_684b4dfd2c748329984e7c47365bc775