### PR TITLE
Fix input props for new coach steps

### DIFF
--- a/src/app/(standalone)/new-coach/_steps/Step1.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step1.tsx
@@ -9,7 +9,7 @@ export default function Step1({ question, value, onChange }: StepProps) {
       <p className="text-center text-lg text-main">{question}</p>
       <Input
         id={`answer-1`}
-        value={value}
+        initialValue={value}
         onChange={(e) => onChange((e.target as HTMLInputElement).value)}
         inputClassName="border-main bg-transparent"
         readOnly={false}

--- a/src/app/(standalone)/new-coach/_steps/Step10.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step10.tsx
@@ -9,7 +9,7 @@ export default function Step10({ question, value, onChange }: StepProps) {
       <p className="text-center text-lg text-main">{question}</p>
       <Input
         id={`answer-10`}
-        value={value}
+        initialValue={value}
         onChange={(e) => onChange((e.target as HTMLInputElement).value)}
         inputClassName="border-main bg-transparent"
         readOnly={false}

--- a/src/app/(standalone)/new-coach/_steps/Step2.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step2.tsx
@@ -9,7 +9,7 @@ export default function Step2({ question, value, onChange }: StepProps) {
       <p className="text-center text-lg text-main">{question}</p>
       <Input
         id={`answer-2`}
-        value={value}
+        initialValue={value}
         onChange={(e) => onChange((e.target as HTMLInputElement).value)}
         inputClassName="border-main bg-transparent"
         readOnly={false}

--- a/src/app/(standalone)/new-coach/_steps/Step3.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step3.tsx
@@ -9,7 +9,7 @@ export default function Step3({ question, value, onChange }: StepProps) {
       <p className="text-center text-lg text-main">{question}</p>
       <Input
         id={`answer-3`}
-        value={value}
+        initialValue={value}
         onChange={(e) => onChange((e.target as HTMLInputElement).value)}
         inputClassName="border-main bg-transparent"
         readOnly={false}

--- a/src/app/(standalone)/new-coach/_steps/Step4.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step4.tsx
@@ -9,7 +9,7 @@ export default function Step4({ question, value, onChange }: StepProps) {
       <p className="text-center text-lg text-main">{question}</p>
       <Input
         id={`answer-4`}
-        value={value}
+        initialValue={value}
         onChange={(e) => onChange((e.target as HTMLInputElement).value)}
         inputClassName="border-main bg-transparent"
         readOnly={false}

--- a/src/app/(standalone)/new-coach/_steps/Step5.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step5.tsx
@@ -9,7 +9,7 @@ export default function Step5({ question, value, onChange }: StepProps) {
       <p className="text-center text-lg text-main">{question}</p>
       <Input
         id={`answer-5`}
-        value={value}
+        initialValue={value}
         onChange={(e) => onChange((e.target as HTMLInputElement).value)}
         inputClassName="border-main bg-transparent"
         readOnly={false}

--- a/src/app/(standalone)/new-coach/_steps/Step6.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step6.tsx
@@ -9,7 +9,7 @@ export default function Step6({ question, value, onChange }: StepProps) {
       <p className="text-center text-lg text-main">{question}</p>
       <Input
         id={`answer-6`}
-        value={value}
+        initialValue={value}
         onChange={(e) => onChange((e.target as HTMLInputElement).value)}
         inputClassName="border-main bg-transparent"
         readOnly={false}

--- a/src/app/(standalone)/new-coach/_steps/Step7.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step7.tsx
@@ -9,7 +9,7 @@ export default function Step7({ question, value, onChange }: StepProps) {
       <p className="text-center text-lg text-main">{question}</p>
       <Input
         id={`answer-7`}
-        value={value}
+        initialValue={value}
         onChange={(e) => onChange((e.target as HTMLInputElement).value)}
         inputClassName="border-main bg-transparent"
         readOnly={false}

--- a/src/app/(standalone)/new-coach/_steps/Step8.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step8.tsx
@@ -9,7 +9,7 @@ export default function Step8({ question, value, onChange }: StepProps) {
       <p className="text-center text-lg text-main">{question}</p>
       <Input
         id={`answer-8`}
-        value={value}
+        initialValue={value}
         onChange={(e) => onChange((e.target as HTMLInputElement).value)}
         inputClassName="border-main bg-transparent"
         readOnly={false}

--- a/src/app/(standalone)/new-coach/_steps/Step9.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step9.tsx
@@ -9,7 +9,7 @@ export default function Step9({ question, value, onChange }: StepProps) {
       <p className="text-center text-lg text-main">{question}</p>
       <Input
         id={`answer-9`}
-        value={value}
+        initialValue={value}
         onChange={(e) => onChange((e.target as HTMLInputElement).value)}
         inputClassName="border-main bg-transparent"
         readOnly={false}


### PR DESCRIPTION
## Summary
- pass `initialValue` to `Input` components in new coach step pages

## Testing
- `npm run build` *(fails: prettier errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b550276688329b4fff0ea8fdfee95