### PR TITLE
Adjust step inputs to use expanding textarea

### DIFF
--- a/src/app/(standalone)/new-coach/_steps/Step1.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step1.tsx
@@ -10,10 +10,11 @@ export default function Step1({question, subquestion, placeholder, value, onChan
       <p className="text-center text-base text-gray-400 -mt-3">{subquestion}</p>
       <Input
         id={`answer-1`}
+        type="textarea"
         initialValue={value}
         placeholder={placeholder + "..."}
-        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
-        inputClassName="border-white/60 bg-white/20"
+        onChange={(e) => onChange((e.target as HTMLTextAreaElement).value)}
+        inputClassName="border-white/60 bg-white/20 !max-h-28"
         readOnly={false}
       />
     </div>

--- a/src/app/(standalone)/new-coach/_steps/Step10.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step10.tsx
@@ -10,10 +10,11 @@ export default function Step10({ question, subquestion, placeholder, value, onCh
       <p className="text-center text-base text-gray-400 -mt-3">{subquestion}</p>
       <Input
         id={`answer-10`}
+        type="textarea"
         initialValue={value}
         placeholder={placeholder + "..."}
-        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
-        inputClassName="border-white/60 bg-white/20"
+        onChange={(e) => onChange((e.target as HTMLTextAreaElement).value)}
+        inputClassName="border-white/60 bg-white/20 !max-h-28"
         readOnly={false}
       />
     </div>

--- a/src/app/(standalone)/new-coach/_steps/Step2.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step2.tsx
@@ -10,10 +10,11 @@ export default function Step2({question, subquestion, placeholder, value, onChan
       <p className="text-center text-base text-gray-400 -mt-3">{subquestion}</p>
       <Input
         id={`answer-2`}
+        type="textarea"
         initialValue={value}
         placeholder={placeholder + "..."}
-        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
-        inputClassName="border-white/60 bg-white/20"
+        onChange={(e) => onChange((e.target as HTMLTextAreaElement).value)}
+        inputClassName="border-white/60 bg-white/20 !max-h-28"
         readOnly={false}
       />
     </div>

--- a/src/app/(standalone)/new-coach/_steps/Step3.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step3.tsx
@@ -10,10 +10,11 @@ export default function Step3({ question, subquestion, placeholder, value, onCha
       <p className="text-center text-base text-gray-400 -mt-3">{subquestion}</p>
       <Input
         id={`answer-3`}
+        type="textarea"
         initialValue={value}
         placeholder={placeholder + "..."}
-        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
-        inputClassName="border-white/60 bg-white/20"
+        onChange={(e) => onChange((e.target as HTMLTextAreaElement).value)}
+        inputClassName="border-white/60 bg-white/20 !max-h-28"
         readOnly={false}
       />
     </div>

--- a/src/app/(standalone)/new-coach/_steps/Step4.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step4.tsx
@@ -10,10 +10,11 @@ export default function Step4({ question, subquestion, placeholder, value, onCha
       <p className="text-center text-base text-gray-400 -mt-3">{subquestion}</p>
       <Input
         id={`answer-4`}
+        type="textarea"
         initialValue={value}
         placeholder={placeholder + "..."}
-        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
-        inputClassName="border-white/60 bg-white/20"
+        onChange={(e) => onChange((e.target as HTMLTextAreaElement).value)}
+        inputClassName="border-white/60 bg-white/20 !max-h-28"
         readOnly={false}
       />
     </div>

--- a/src/app/(standalone)/new-coach/_steps/Step5.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step5.tsx
@@ -10,10 +10,11 @@ export default function Step5({ question, subquestion, placeholder, value, onCha
       <p className="text-center text-base text-gray-400 -mt-3">{subquestion}</p>
       <Input
         id={`answer-5`}
+        type="textarea"
         initialValue={value}
         placeholder={placeholder + "..."}
-        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
-        inputClassName="border-white/60 bg-white/20"
+        onChange={(e) => onChange((e.target as HTMLTextAreaElement).value)}
+        inputClassName="border-white/60 bg-white/20 !max-h-28"
         readOnly={false}
       />
     </div>

--- a/src/app/(standalone)/new-coach/_steps/Step6.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step6.tsx
@@ -10,10 +10,11 @@ export default function Step6({ question, subquestion, placeholder, value, onCha
       <p className="text-center text-base text-gray-400 -mt-3">{subquestion}</p>
       <Input
         id={`answer-6`}
+        type="textarea"
         initialValue={value}
         placeholder={placeholder + "..."}
-        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
-        inputClassName="border-white/60 bg-white/20"
+        onChange={(e) => onChange((e.target as HTMLTextAreaElement).value)}
+        inputClassName="border-white/60 bg-white/20 !max-h-28"
         readOnly={false}
       />
     </div>

--- a/src/app/(standalone)/new-coach/_steps/Step7.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step7.tsx
@@ -10,10 +10,11 @@ export default function Step7({ question, subquestion, placeholder, value, onCha
       <p className="text-center text-base text-gray-400 -mt-3">{subquestion}</p>
       <Input
         id={`answer-7`}
+        type="textarea"
         initialValue={value}
         placeholder={placeholder + "..."}
-        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
-        inputClassName="border-white/60 bg-white/20"
+        onChange={(e) => onChange((e.target as HTMLTextAreaElement).value)}
+        inputClassName="border-white/60 bg-white/20 !max-h-28"
         readOnly={false}
       />
     </div>

--- a/src/app/(standalone)/new-coach/_steps/Step8.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step8.tsx
@@ -10,10 +10,11 @@ export default function Step8({ question, subquestion, placeholder, value, onCha
       <p className="text-center text-base text-gray-400 -mt-3">{subquestion}</p>
       <Input
         id={`answer-8`}
+        type="textarea"
         initialValue={value}
         placeholder={placeholder + "..."}
-        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
-        inputClassName="border-white/60 bg-white/20"
+        onChange={(e) => onChange((e.target as HTMLTextAreaElement).value)}
+        inputClassName="border-white/60 bg-white/20 !max-h-28"
         readOnly={false}
       />
     </div>

--- a/src/app/(standalone)/new-coach/_steps/Step9.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step9.tsx
@@ -10,10 +10,11 @@ export default function Step9({ question, subquestion, placeholder, value, onCha
       <p className="text-center text-base text-gray-400 -mt-3">{subquestion}</p>
       <Input
         id={`answer-9`}
+        type="textarea"
         initialValue={value}
         placeholder={placeholder + "..."}
-        onChange={(e) => onChange((e.target as HTMLInputElement).value)}
-        inputClassName="border-white/60 bg-white/20"
+        onChange={(e) => onChange((e.target as HTMLTextAreaElement).value)}
+        inputClassName="border-white/60 bg-white/20 !max-h-28"
         readOnly={false}
       />
     </div>


### PR DESCRIPTION
## Summary
- allow multiline input in all new coach steps

## Testing
- `npm run lint` *(fails: prettier errors)*

------
https://chatgpt.com/codex/tasks/task_e_684f30a6770483299fece6a857b810c4