### PR TITLE
Update Step6 with dynamic link inputs

### DIFF
--- a/src/app/(standalone)/new-coach/_steps/Step6.tsx
+++ b/src/app/(standalone)/new-coach/_steps/Step6.tsx
@@ -1,22 +1,110 @@
 "use client";
 
+import { useState } from "react";
 import { Input } from "@/shared/Input";
+import { Button } from "@/shared/Button";
 import { StepProps } from "./StepProps";
 
-export default function Step6({ question, subquestion, placeholder, value, onChange }: StepProps) {
+export default function Step6({
+  question,
+  subquestion,
+  placeholder,
+  value,
+  onChange,
+}: StepProps) {
+  const [rows, setRows] = useState<{ value: string; added: boolean }[]>(() => {
+    if (value.trim().length) {
+      return value
+        .split("\n")
+        .filter((v) => v.trim().length)
+        .map((v) => ({ value: v, added: true }));
+    }
+
+    return [{ value: "", added: false }];
+  });
+
+  const updateParent = (r: { value: string; added: boolean }[]) => {
+    onChange(r.filter((row) => row.added).map((row) => row.value).join("\n"));
+  };
+
+  const handleInputChange = (index: number, val: string) => {
+    setRows((prev) => {
+      const copy = [...prev];
+      copy[index].value = val;
+      if (copy[index].added) {
+        updateParent(copy);
+      }
+      return copy;
+    });
+  };
+
+  const handleAddToggle = (index: number) => {
+    setRows((prev) => {
+      const copy = [...prev];
+      if (!copy[index].added) {
+        copy[index].added = true;
+      } else {
+        copy.splice(index, 1);
+      }
+
+      if (!copy.length) {
+        copy.push({ value: "", added: false });
+      }
+
+      updateParent(copy);
+      return copy;
+    });
+  };
+
+  const handleAddRow = (index: number) => {
+    setRows((prev) => {
+      const copy = [...prev];
+      copy.splice(index + 1, 0, { value: "", added: false });
+      return copy;
+    });
+  };
+
   return (
     <div className="flex w-full max-w-xl flex-col gap-y-4">
       <p className="text-center text-2xl text-main font-bold">{question}</p>
       <p className="text-center text-base text-gray-400 -mt-3">{subquestion}</p>
-      <Input
-        id={`answer-6`}
-        type="textarea"
-        initialValue={value}
-        placeholder={placeholder + "..."}
-        onChange={(e) => onChange((e.target as HTMLTextAreaElement).value)}
-        inputClassName="border-white/60 bg-white/20 !max-h-28"
-        readOnly={false}
-      />
+
+      {rows.map((row, i) => (
+        <div key={i} className="flex flex-col gap-y-2">
+          <div className="flex items-center gap-x-2">
+            <Input
+              key={`input-${i}`}
+              id={`answer-6-${i}`}
+              type="url"
+              placeholder={placeholder + "..."}
+              initialValue={row.value}
+              onChange={(e) =>
+                handleInputChange(i, (e.target as HTMLInputElement).value)
+              }
+              inputClassName="border-white/60 bg-white/20"
+              readOnly={false}
+            />
+            <Button
+              type="button"
+              variant="solid"
+              color="gray"
+              className={row.added ? "cbi-trash aspect-square p-3" : "px-4"}
+              onClick={() => handleAddToggle(i)}
+            >
+              {row.added ? "" : "Add"}
+            </Button>
+          </div>
+          {row.added && i === rows.length - 1 && (
+            <Button
+              type="button"
+              variant="solid"
+              color="gray"
+              className="cbi-add self-start aspect-square p-2 text-lg"
+              onClick={() => handleAddRow(i)}
+            />
+          )}
+        </div>
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow adding multiple link fields in step6
- toggle add/trash button per field
- show plus button to append new fields

## Testing
- `npm run lint` *(fails: prettier errors)*
- `npm run build` *(fails during type checking)*

------
https://chatgpt.com/codex/tasks/task_e_684f443e177483299452408878e288a9